### PR TITLE
Update Description - language.json

### DIFF
--- a/v2.x/src/language.json
+++ b/v2.x/src/language.json
@@ -8,7 +8,8 @@
         "it": ["Do","Lu","Ma","Me","Gi","Ve","Sa"],
         "tr": ["Pzt", "Sal", "Çar", "Per", "Cum", "Cmt", "Paz"],
         "id": ["Min", "Sen", "Sel", "Rab", "Kam", "Jum", "Sab"],
-        "uk": ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"]
+        "uk": ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"],
+        "pt-br": ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"]
     },
     "month3": {
         "ru": ["Янв", "Фев", "Мар", "Апр", "Май", "Июн", "Июл", "Авг", "Сен", "Окт", "Ноя", "Дек"],
@@ -19,7 +20,8 @@
         "it": ["Gen", "Feb", "Mar", "Apr", "Mag", "Giu", "Lug", "Ago", "Set", "Ott", "Nov", "Dic"],
         "tr": ["Oca", "Şub", "Mar", "Nis", "May", "Haz", "Tem", "Ağu", "Eyl", "Eki", "Kas", "Ara"],
         "id": ["Jan", "Feb", "Mar", "Apr", "Mei", "Jun", "Jul", "Ags", "Sep", "Okt", "Nov", "Des"],
-        "uk": ["Січ", "Лют", "Бер", "Кві", "Тра", "Чер", "Лип", "Сер", "Вер", "Жов", "Лис", "Гру"]
+        "uk": ["Січ", "Лют", "Бер", "Кві", "Тра", "Чер", "Лип", "Сер", "Вер", "Жов", "Лис", "Гру"],
+        "pt-br": ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"]
     },
     "pick": {
         "ru": "Выберите календарь",
@@ -30,7 +32,8 @@
         "it": "Scegli un calendario",
         "tr": "Bir takvim seçin",
         "id": "Pilih Kalendernya kak",
-        "uk": "Виберіть календар"
+        "uk": "Виберіть календар",
+        "pt-br": "Escolha um calendário"
     },
     "select": {
         "ru": "Пожалуйста, выберите дату:",
@@ -41,29 +44,32 @@
         "it": "Seleziona una data:",
         "tr": "Lütfen bir tarih seçin:",
         "id": "Pilih Tanggalnya kak",
-        "uk": "Будь ласка, виберіть дату:"
+        "uk": "Будь ласка, виберіть дату:",
+        "pt-br": "Por favor, selecione uma data:"
     },
     "selecttime": {
         "ru": "Пожалуйста, выберите время:",
         "en": "Please select a time:",
         "de": "Bitte wählen Sie eine Zeit aus:",
-        "es": "Seleccione una hora:",
+        "es": "Seleccione uma hora:",
         "fr": "Veuillez sélectionner une heure:",
-        "it": "Seleziona un orario:",
+        "it": "Seleziona un horário:",
         "tr": "Lütfen bir zaman seçin:",
         "id": "Pilih Waktunya Kak",
-        "uk": "Будь ласка, виберіть час:"
+        "uk": "Будь ласка, виберіть час:",
+        "pt-br": "Por favor, selecione um horário:"
     },
     "selectdatetime": {
         "ru": "Пожалуйста, выберите дату и время:",
         "en": "Please select a date and time:",
         "de": "Bitte wählen Sie ein Datum und eine Uhrzeit aus:",
-        "es": "Por favor seleccione una fecha y hora:",
+        "es": "Por favor seleccione uma fecha y hora:",
         "fr": "Veuillez sélectionner une date et une heure:",
-        "it": "Si prega di selezionare una data e un'ora:",
+        "it": "Si prega di selezionare uma data e un'ora:",
         "tr": "Lütfen bir tarih ve zaman seçin:",
         "id": "Pilih Tanggal Dan Waktunya Kak",
-        "uk": "Будь ласка, виберіть дату та час:"
+        "uk": "Будь ласка, виберіть дату та час:",
+        "pt-br": "Por favor, selecione uma data e horário:"
     },
     "navigafion": {
         "ru": "Навигационный календарь",
@@ -74,7 +80,8 @@
         "it": "Calendario di navigazione",
         "tr": "Navigasyon Takvimi",
         "id": "Kalender Navigasi",
-        "uk": "Навігаційний календар"
+        "uk": "Навігаційний календар",
+        "pt-br": "Calendário de navegação"
     },
     "dialog": {
         "ru": "Диалоговый календарь",
@@ -85,7 +92,8 @@
         "it": "Calendario di dialogo",
         "tr": "Diyalog Takvimi",
         "id": "Kalender Dialog",
-        "uk": "Діалоговий календар"
+        "uk": "Діалоговий календар",
+        "pt-br": "Calendário de diálogo"
     },
     "back": {
         "ru": "Назад",
@@ -96,7 +104,8 @@
         "it": "Indietro",
         "tr": "Geri",
         "id": "Balik",
-        "uk": "Назад"
+        "uk": "Назад",
+        "pt-br": "Voltar"
     },
     "selectlang": {
         "ru": "Выберите язык:",
@@ -107,7 +116,8 @@
         "it": "Seleziona la lingua:",
         "tr": "Dil seçin:",
         "id": "Pilih bahasa:",
-        "uk": "Виберіть мову:"
+        "uk": "Виберіть мову:",
+        "pt-br": "Selecione um idioma:"
     },
     "selectuserlang": {
         "ru": "Русский🇷🇺",
@@ -118,7 +128,7 @@
         "it": "Italiano🇮🇹",
         "tr": "Türkçe🇹🇷",
         "id": "Indonesia🇮🇩",
-        "uk": "Українська🇺🇦"
+        "uk": "Українська🇺🇦",
+        "pt-br": "Português🇧🇷"
     }
 }
-  


### PR DESCRIPTION
Update Description

Added support for Brazilian Portuguese (pt-BR) in the calendar translations. Now, Portuguese-speaking users can view weekdays, months, and system messages in their native language.

Changes made:
Added "pt-br" to the week key with weekdays: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"].

Added "pt-br" to the month3 key with abbreviated months: ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"].

Added "pt-br" translations for system messages, such as date, time, and language selection.

This update enhances accessibility and improves the user experience for Brazilian users, making the calendar more intuitive to use. 🚀